### PR TITLE
Add `GUtil` project

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ To retrieve the value of a (test) environment variable, use the ```EnvironmentVa
 String value = environmentVariables.envVarOrFromTestingProperty("FOO").get(); 
 ```
 
+## GUtil
+
+The `GUtil` class in the `org.gradle.util` package has been deprecated and will be banned at some point. There are some very useful methods in here, notably around camel casing for use as task names. This library provides a selection of these methods. Please add more as needed, but try to avoid adding methods that are not used by any of the plugins. 
+

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,6 @@ allprojects {
 
 javaVersions {
     libraryTarget = 11
-    runtime = 21
+    runtime = 17
 }
 

--- a/changelog/@unreleased/pr-82.v2.yml
+++ b/changelog/@unreleased/pr-82.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add `gutil` project that has a copy of parts of `GUtil` (initially
+    just the camel case pieces).
+  links:
+  - https://github.com/palantir/gradle-utils/pull/82

--- a/gutil/build.gradle
+++ b/gutil/build.gradle
@@ -1,0 +1,7 @@
+apply plugin: 'java-library'
+apply plugin: 'com.palantir.external-publish-jar'
+
+dependencies {
+    implementation gradleApi()
+    implementation 'org.apache.commons:commons-lang3'
+}

--- a/gutil/src/main/java/com/palantir/gradle/utils/gutil/CamelCaseUtils.java
+++ b/gutil/src/main/java/com/palantir/gradle/utils/gutil/CamelCaseUtils.java
@@ -20,7 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
-public final class GUtil {
+public final class CamelCaseUtils {
     private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
 
     public static String toLowerCamelCase(CharSequence string) {
@@ -64,5 +64,5 @@ public final class GUtil {
         return builder.toString();
     }
 
-    private GUtil() {}
+    private CamelCaseUtils() {}
 }

--- a/gutil/src/main/java/com/palantir/gradle/utils/gutil/GUtil.java
+++ b/gutil/src/main/java/com/palantir/gradle/utils/gutil/GUtil.java
@@ -1,0 +1,68 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.utils.gutil;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
+
+final class GUtil {
+    private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
+
+    public static String toLowerCamelCase(CharSequence string) {
+        return toCamelCase(string, true);
+    }
+
+    public static String toCamelCase(CharSequence string) {
+        return toCamelCase(string, false);
+    }
+
+    // Taken from the now deprecated Gradle GUtil class
+    private static String toCamelCase(CharSequence string, boolean lower) {
+        if (string == null) {
+            return null;
+        }
+        StringBuilder builder = new StringBuilder();
+        Matcher matcher = WORD_SEPARATOR.matcher(string);
+        int pos = 0;
+        boolean first = true;
+        while (matcher.find()) {
+            String chunk = string.subSequence(pos, matcher.start()).toString();
+            pos = matcher.end();
+            if (chunk.isEmpty()) {
+                continue;
+            }
+            if (lower && first) {
+                chunk = StringUtils.uncapitalize(chunk);
+                first = false;
+            } else {
+                chunk = StringUtils.capitalize(chunk);
+            }
+            builder.append(chunk);
+        }
+        String rest = string.subSequence(pos, string.length()).toString();
+        if (lower && first) {
+            rest = StringUtils.uncapitalize(rest);
+        } else {
+            rest = StringUtils.capitalize(rest);
+        }
+        builder.append(rest);
+        return builder.toString();
+    }
+
+    private GUtil() {}
+}

--- a/gutil/src/main/java/com/palantir/gradle/utils/gutil/GUtil.java
+++ b/gutil/src/main/java/com/palantir/gradle/utils/gutil/GUtil.java
@@ -20,7 +20,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 
-final class GUtil {
+public final class GUtil {
     private static final Pattern WORD_SEPARATOR = Pattern.compile("\\W+");
 
     public static String toLowerCamelCase(CharSequence string) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'gradle-utils'
 
-include 'lazily-configured-mapping'
 include 'environment-variables'
+include 'gutil'
+include 'lazily-configured-mapping'

--- a/versions.lock
+++ b/versions.lock
@@ -1,4 +1,5 @@
 # Run ./gradlew --write-locks to regenerate this file
+org.apache.commons:commons-lang3:3.13.0 (1 constraints: 39053e3b)
 
 [Test dependencies]
 cglib:cglib-nodep:3.2.2 (1 constraints: 490ded24)

--- a/versions.props
+++ b/versions.props
@@ -1,3 +1,5 @@
+org.apache.commons:commons-lang3 = 3.13.0
+
 org.junit.jupiter:* = 5.10.0
 org.assertj:assertj-core = 3.24.2
 com.netflix.nebula:nebula-test = 10.0.0


### PR DESCRIPTION
## Before this PR
`org.gradle.util.GUtil` is deprecated and going to be removed in Gradle 9. There are some useful methods in it we likely want to keep using and it sucks to be copy pasting it into each project that needs it.

## After this PR
==COMMIT_MSG==
Add `gutil` project that has a copy of parts of `GUtil` (initially just the camel case pieces).
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

