### PR TITLE
Add dependency-graph-utils to get all components from root

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,8 @@ String value = environmentVariables.envVarOrFromTestingProperty("FOO").get();
 
 The `GUtil` class in the `org.gradle.util` package has been deprecated and will be banned at some point. There are some very useful methods in here, notably around camel casing for use as task names. This library provides a selection of these methods. Please add more as needed, but try to avoid adding methods that are not used by any of the plugins. 
 
+## dependency-graph-utils
+
+[To support Configuration Cache, you need to use new APIs](https://docs.gradle.org/8.4/userguide/configuration_cache.html#config_cache:requirements:~:text=Referencing%20dependency%20resolution,invoking%20ResolutionResult.getRootComponent()) when passing the components of a resolved `Configuration` to a `Task`. No longer can you pass in the `Configuration` object then use it in the task, instead you must call the method [`Provider<ResolvedComponentResult> getRootComponent()`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/artifacts/result/ResolutionResult.html#getRootComponent--) on `ResolutionResult` rather than [`Set<ResolvedComponentResult> getAllComponents()`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/artifacts/result/ResolutionResult.html#getAllComponents--).
+
+The problem is that this just gives you the root - you need to do a search of the graph yourself to get all the components. This library provides a utility method to do this for you: `DependencyGraphUtils#getAllComponents(ResolvedComponentResult)`.

--- a/changelog/@unreleased/pr-84.v2.yml
+++ b/changelog/@unreleased/pr-84.v2.yml
@@ -1,0 +1,6 @@
+type: feature
+feature:
+  description: Add `dependency-graph-utils` which provides a way to get all components
+    from a root component in order to help support Configuration Cache rollout.
+  links:
+  - https://github.com/palantir/gradle-utils/pull/84

--- a/dependency-graph-utils/build.gradle
+++ b/dependency-graph-utils/build.gradle
@@ -1,0 +1,11 @@
+apply plugin: 'java-library'
+apply plugin: 'groovy'
+apply plugin: 'com.palantir.external-publish-jar'
+
+dependencies {
+    implementation gradleApi()
+
+    testImplementation 'org.assertj:assertj-core'
+    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'com.netflix.nebula:nebula-test'
+}

--- a/dependency-graph-utils/src/main/java/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtils.java
+++ b/dependency-graph-utils/src/main/java/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtils.java
@@ -1,0 +1,75 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.utils.dependencygraph;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import org.gradle.api.artifacts.result.ResolvedComponentResult;
+import org.gradle.api.artifacts.result.ResolvedDependencyResult;
+import org.gradle.api.artifacts.result.UnresolvedDependencyResult;
+import org.gradle.api.attributes.Attribute;
+
+public final class DependencyGraphUtils {
+    public static Set<ResolvedComponentResult> allComponentResultsFromRoot(ResolvedComponentResult rootResult) {
+        Set<ResolvedComponentResult> seen = new HashSet<>();
+        Queue<ResolvedComponentResult> next = new ArrayDeque<>();
+
+        next.add(rootResult);
+
+        ResolvedComponentResult current;
+        while ((current = next.poll()) != null) {
+            // GCV makes a project dependency on the root project for a "platform" of version constraints. This exists
+            // in every configuration that GCV inserts constraints into and is not a mavenBundle dep. However, there
+            // can be a real mavenBundle dep as well that presents itself as another variant. So we must reject
+            // component results that have just the GCV variant but not if there is another variant too.
+            boolean onlySelectedForGcvProps = current.getVariants().stream()
+                    .allMatch(resolvedVariantResult -> Optional.ofNullable(resolvedVariantResult
+                                    .getAttributes()
+                                    .getAttribute(Attribute.of("org.gradle.usage", String.class)))
+                            .equals(Optional.of("consistent-versions-usage")));
+
+            if (onlySelectedForGcvProps) {
+                continue;
+            }
+
+            seen.add(current);
+
+            current.getDependencies().forEach(dependencyResult -> {
+                if (dependencyResult instanceof UnresolvedDependencyResult) {
+                    throw new RuntimeException(
+                            "Failed to resolve "
+                                    + dependencyResult.getRequested().getDisplayName(),
+                            ((UnresolvedDependencyResult) dependencyResult).getFailure());
+                }
+
+                ResolvedDependencyResult resolvedDependencyResult = (ResolvedDependencyResult) dependencyResult;
+                ResolvedComponentResult resolvedComponentResult = resolvedDependencyResult.getSelected();
+
+                if (!seen.contains(resolvedComponentResult)) {
+                    next.add(resolvedComponentResult);
+                }
+            });
+        }
+
+        return seen;
+    }
+
+    private DependencyGraphUtils() {}
+}

--- a/dependency-graph-utils/src/test/groovy/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtilsIntegrationSpec.groovy
+++ b/dependency-graph-utils/src/test/groovy/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtilsIntegrationSpec.groovy
@@ -1,0 +1,226 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.gradle.utils.dependencygraph
+
+import nebula.test.IntegrationSpec
+
+class DependencyGraphUtilsIntegrationSpec extends IntegrationSpec {
+    File subprojectDir
+    File subprojectBuildFile
+
+    def setup() {
+        // language=Gradle
+        settingsFile << '''
+            rootProject.name = 'root'
+        '''.stripIndent(true)
+
+        // language=Gradle
+        buildFile << '''
+            buildscript {
+                repositories {
+                    mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+                }
+            
+                dependencies {
+                    classpath 'com.palantir.gradle.consistentversions:gradle-consistent-versions:2.16.0'
+                }
+            }
+            
+            allprojects {
+                repositories {
+                    mavenCentral() { metadataSources { mavenPom(); ignoreGradleMetadataRedirection() } }
+                }
+                
+                apply plugin: 'java-library'
+            }
+        '''.stripIndent(true)
+
+        // language=Gradle
+        subprojectDir = addSubproject 'subproject', '''
+            import com.palantir.gradle.utils.dependencygraph.DependencyGraphUtils
+
+            task printAllDeps {
+                outputs.file('build/allDeps')
+            
+                doFirst {
+                    def root = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent.get()
+                    def all = DependencyGraphUtils.allComponentResultsFromRoot(root)
+                    outputs.files.singleFile << all.collect { it.toString() }.sort().join('\\n')
+                }
+            }
+        '''.stripIndent(true)
+
+        subprojectBuildFile = new File(subprojectDir, 'build.gradle')
+
+        writeHelloWorld()
+        writeHelloWorld(subprojectDir)
+
+        file('versions.props') << '''
+        com.google.guava:guava = 30.1.1-jre
+        com.palantir.conjure.java:* = 7.21.0
+        '''.stripIndent(true)
+
+        file('versions.lock')
+    }
+
+    def 'prints all deps successfully without GCV, with a dep on root project'() {
+        // language=Gradle
+        subprojectBuildFile << '''
+            dependencies {
+                implementation 'com.palantir.conjure.java:conjure-java-core:7.21.0'
+                implementation rootProject
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('printAllDeps')
+
+        then:
+        def allDeps = new File(subprojectDir, 'build/allDeps').text.strip()
+
+        def expected = '''
+            com.atlassian.commonmark:commonmark:0.12.1
+            com.fasterxml.jackson.core:jackson-annotations:2.15.3
+            com.fasterxml.jackson.core:jackson-core:2.15.3
+            com.fasterxml.jackson.core:jackson-databind:2.15.3
+            com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3
+            com.fasterxml.jackson.datatype:jackson-datatype-guava:2.13.3
+            com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.3
+            com.google.code.findbugs:jsr305:3.0.2
+            com.google.errorprone:error_prone_annotations:2.21.1
+            com.google.guava:failureaccess:1.0.1
+            com.google.guava:guava:32.1.3-jre
+            com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+            com.google.j2objc:j2objc-annotations:2.8
+            com.palantir.common:streams:2.2.0
+            com.palantir.conjure.java.api:errors:2.38.0
+            com.palantir.conjure.java:conjure-java-core:7.21.0
+            com.palantir.conjure.java:conjure-lib:7.21.0
+            com.palantir.conjure.java:conjure-undertow-lib:7.21.0
+            com.palantir.conjure:conjure-api-objects:4.36.0
+            com.palantir.conjure:conjure-generator-common:4.36.0
+            com.palantir.dialogue:dialogue-target:3.97.0
+            com.palantir.goethe:goethe:0.11.0
+            com.palantir.human-readable-types:human-readable-types:1.6.0
+            com.palantir.ri:resource-identifier:2.6.0
+            com.palantir.safe-logging:logger-slf4j:3.6.0
+            com.palantir.safe-logging:logger-spi:3.6.0
+            com.palantir.safe-logging:logger:3.6.0
+            com.palantir.safe-logging:preconditions:3.6.0
+            com.palantir.safe-logging:safe-logging:3.6.0
+            com.palantir.syntactic-paths:syntactic-paths:0.9.0
+            com.palantir.tokens:auth-tokens:3.18.0
+            com.squareup:javapoet:1.13.0
+            io.undertow:undertow-core:2.2.24.Final
+            jakarta.annotation:jakarta.annotation-api:1.3.5
+            jakarta.ws.rs:jakarta.ws.rs-api:2.1.6
+            org.apache.commons:commons-lang3:3.13.0
+            org.checkerframework:checker-qual:3.37.0
+            org.glassfish.hk2.external:jakarta.inject:2.6.1
+            org.glassfish.hk2:osgi-resource-locator:1.0.3
+            org.glassfish.jersey.core:jersey-common:2.40
+            org.jboss.logging:jboss-logging:3.4.1.Final
+            org.jboss.threads:jboss-threads:3.1.0.Final
+            org.jboss.xnio:xnio-api:3.8.7.Final
+            org.jboss.xnio:xnio-nio:3.8.7.Final
+            org.jetbrains:annotations:24.0.1
+            org.slf4j:slf4j-api:1.7.36
+            org.wildfly.client:wildfly-client-config:1.0.1.Final
+            org.wildfly.common:wildfly-common:1.6.0.Final
+            org.yaml:snakeyaml:2.1
+            project :
+            project :subproject
+        '''.stripIndent(true).strip()
+
+        allDeps == expected
+    }
+
+    def 'prints all deps successfully with GCV, not including dep on root project via GCV'() {
+        // language=Gradle
+        buildFile << '''
+            apply plugin: 'com.palantir.consistent-versions'
+        '''.stripIndent(true)
+
+        // language=Gradle
+        subprojectBuildFile << '''
+            dependencies {
+                implementation 'com.palantir.conjure.java:conjure-java-core:7.21.0'
+            }
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('printAllDeps')
+
+        then:
+        def allDeps = new File(subprojectDir, 'build/allDeps').text.strip()
+
+        def expected = '''
+            com.atlassian.commonmark:commonmark:0.12.1
+            com.fasterxml.jackson.core:jackson-annotations:2.15.3
+            com.fasterxml.jackson.core:jackson-core:2.15.3
+            com.fasterxml.jackson.core:jackson-databind:2.15.3
+            com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.3
+            com.fasterxml.jackson.datatype:jackson-datatype-guava:2.13.3
+            com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.3
+            com.google.code.findbugs:jsr305:3.0.2
+            com.google.errorprone:error_prone_annotations:2.21.1
+            com.google.guava:failureaccess:1.0.1
+            com.google.guava:guava:32.1.3-jre
+            com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava
+            com.google.j2objc:j2objc-annotations:2.8
+            com.palantir.common:streams:2.2.0
+            com.palantir.conjure.java.api:errors:2.38.0
+            com.palantir.conjure.java:conjure-java-core:7.21.0
+            com.palantir.conjure.java:conjure-lib:7.21.0
+            com.palantir.conjure.java:conjure-undertow-lib:7.21.0
+            com.palantir.conjure:conjure-api-objects:4.36.0
+            com.palantir.conjure:conjure-generator-common:4.36.0
+            com.palantir.dialogue:dialogue-target:3.97.0
+            com.palantir.goethe:goethe:0.11.0
+            com.palantir.human-readable-types:human-readable-types:1.6.0
+            com.palantir.ri:resource-identifier:2.6.0
+            com.palantir.safe-logging:logger-slf4j:3.6.0
+            com.palantir.safe-logging:logger-spi:3.6.0
+            com.palantir.safe-logging:logger:3.6.0
+            com.palantir.safe-logging:preconditions:3.6.0
+            com.palantir.safe-logging:safe-logging:3.6.0
+            com.palantir.syntactic-paths:syntactic-paths:0.9.0
+            com.palantir.tokens:auth-tokens:3.18.0
+            com.squareup:javapoet:1.13.0
+            io.undertow:undertow-core:2.2.24.Final
+            jakarta.annotation:jakarta.annotation-api:1.3.5
+            jakarta.ws.rs:jakarta.ws.rs-api:2.1.6
+            org.apache.commons:commons-lang3:3.13.0
+            org.checkerframework:checker-qual:3.37.0
+            org.glassfish.hk2.external:jakarta.inject:2.6.1
+            org.glassfish.hk2:osgi-resource-locator:1.0.3
+            org.glassfish.jersey.core:jersey-common:2.40
+            org.jboss.logging:jboss-logging:3.4.1.Final
+            org.jboss.threads:jboss-threads:3.1.0.Final
+            org.jboss.xnio:xnio-api:3.8.7.Final
+            org.jboss.xnio:xnio-nio:3.8.7.Final
+            org.jetbrains:annotations:24.0.1
+            org.slf4j:slf4j-api:1.7.36
+            org.wildfly.client:wildfly-client-config:1.0.1.Final
+            org.wildfly.common:wildfly-common:1.6.0.Final
+            org.yaml:snakeyaml:2.1
+            project :subproject
+        '''.stripIndent(true).strip()
+
+        allDeps == expected
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'gradle-utils'
 
+include 'dependency-graph-utils'
 include 'environment-variables'
 include 'gutil'
 include 'lazily-configured-mapping'


### PR DESCRIPTION
## Before this PR
[To support Configuration Cache, you need to use new APIs](https://docs.gradle.org/8.4/userguide/configuration_cache.html#config_cache:requirements:~:text=Referencing%20dependency%20resolution,invoking%20ResolutionResult.getRootComponent()) when passing the components of a resolved `Configuration` to a `Task`. No longer can you pass in the `Configuration` object then use it in the task, instead you must call the method [`Provider<ResolvedComponentResult> getRootComponent()`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/artifacts/result/ResolutionResult.html#getRootComponent--) on `ResolutionResult` rather than [`Set<ResolvedComponentResult> getAllComponents()`](https://docs.gradle.org/8.4/javadoc/org/gradle/api/artifacts/result/ResolutionResult.html#getAllComponents--).

The problem is that this just gives you the root - you need to do a search of the graph yourself to get all the components. To avoid this same code being copy-pasted everywhere I'm going to put it in here. Ideally Gradle would provide a helper method for this that is compatible with configuration cache ([Gradle FR here](https://github.com/gradle/gradle/issues/26897)).

Additionally, doing this search is tricky - GCV adds a dep on the root project that is not "real". There may be some more general way of seeing if these are platforms, however in practice this works well enough.

## After this PR
==COMMIT_MSG==
Add `dependency-graph-utils` which provides a way to get all components from a root component in order to help support Configuration Cache rollout.
==COMMIT_MSG==

## Possible downsides?
* GCV platform detection might be able to be replaced with something more general that detects platforms - I don't know how to do this though.

