### PR TITLE
Fix case when root component is ignored from allComponentResultsFromRoot when there are no variants

### DIFF
--- a/changelog/@unreleased/pr-89.v2.yml
+++ b/changelog/@unreleased/pr-89.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: Root components with no variants are no longer spuriously excluded
+    from `DependencyGraphUtils#allComponentResultsFromRoot`.
+  links:
+  - https://github.com/palantir/gradle-utils/pull/89

--- a/dependency-graph-utils/src/main/java/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtils.java
+++ b/dependency-graph-utils/src/main/java/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtils.java
@@ -39,11 +39,15 @@ public final class DependencyGraphUtils {
             // in every configuration that GCV inserts constraints into and is not a mavenBundle dep. However, there
             // can be a real mavenBundle dep as well that presents itself as another variant. So we must reject
             // component results that have just the GCV variant but not if there is another variant too.
-            boolean onlySelectedForGcvProps = current.getVariants().stream()
-                    .allMatch(resolvedVariantResult -> Optional.ofNullable(resolvedVariantResult
-                                    .getAttributes()
-                                    .getAttribute(Attribute.of("org.gradle.usage", String.class)))
-                            .equals(Optional.of("consistent-versions-usage")));
+            // Where there are no variants, this is still a valid dependency and not a GCV one (`allMatch` is trap
+            // here, as it returns true for an empty stream). Why would there be no variants when GCV always adds the
+            // platform dep? In cases where GCV is not used or when a configuration is copied, so GCV can't get to it.
+            boolean onlySelectedForGcvProps = !current.getVariants().isEmpty()
+                    && current.getVariants().stream()
+                            .allMatch(resolvedVariantResult -> Optional.ofNullable(resolvedVariantResult
+                                            .getAttributes()
+                                            .getAttribute(Attribute.of("org.gradle.usage", String.class)))
+                                    .equals(Optional.of("consistent-versions-usage")));
 
             if (onlySelectedForGcvProps) {
                 continue;

--- a/dependency-graph-utils/src/test/groovy/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtilsIntegrationSpec.groovy
+++ b/dependency-graph-utils/src/test/groovy/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtilsIntegrationSpec.groovy
@@ -54,10 +54,12 @@ class DependencyGraphUtilsIntegrationSpec extends IntegrationSpec {
             import com.palantir.gradle.utils.dependencygraph.DependencyGraphUtils
 
             task printAllDeps {
+                inputs.property('configurationName', 'runtimeClasspath')
                 outputs.file('build/allDeps')
             
                 doFirst {
-                    def root = configurations.runtimeClasspath.incoming.resolutionResult.rootComponent.get()
+                    def root = project.configurations.getByName(inputs.properties.get('configurationName'))
+                            .incoming.resolutionResult.rootComponent.get()
                     def all = DependencyGraphUtils.allComponentResultsFromRoot(root)
                     outputs.files.singleFile << all.collect { it.toString() }.sort().join('\\n')
                 }
@@ -220,6 +222,27 @@ class DependencyGraphUtilsIntegrationSpec extends IntegrationSpec {
             org.yaml:snakeyaml:2.1
             project :subproject
         '''.stripIndent(true).strip()
+
+        allDeps == expected
+    }
+
+    def 'when there is no GCV platform, or any variant on the root, the root is still selected'() {
+        // language=Gradle
+        subprojectBuildFile << '''
+            def runtimeClasspathCopy = configurations.runtimeClasspath.copy()
+
+            printAllDeps.inputs.property('configuration', runtimeClasspathCopy.name)
+        '''.stripIndent(true)
+
+        when:
+        runTasksSuccessfully('printAllDeps')
+
+        then:
+        def allDeps = new File(subprojectDir, 'build/allDeps').text.strip()
+
+        def expected = '''
+            group:subproject:1.0.0
+        '''.stripIndent(true)
 
         allDeps == expected
     }

--- a/dependency-graph-utils/src/test/groovy/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtilsIntegrationSpec.groovy
+++ b/dependency-graph-utils/src/test/groovy/com/palantir/gradle/utils/dependencygraph/DependencyGraphUtilsIntegrationSpec.groovy
@@ -241,8 +241,8 @@ class DependencyGraphUtilsIntegrationSpec extends IntegrationSpec {
         def allDeps = new File(subprojectDir, 'build/allDeps').text.strip()
 
         def expected = '''
-            group:subproject:1.0.0
-        '''.stripIndent(true)
+            project :subproject
+        '''.stripIndent(true).strip()
 
         allDeps == expected
     }


### PR DESCRIPTION
## Before this PR
When `DependencyGraphUtils#allComponentResultsFromRoot` is called with a root that has has no variants (ie GCV has not managed to put a dependency constraints platform on it, like if the configuration has been copied so not visible to GCV), it is ignored as part of GCV platform checks due to a logic error. 

## After this PR
==COMMIT_MSG==
Root components with no variants are no longer spuriously excluded from `DependencyGraphUtils#allComponentResultsFromRoot`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

