### PR TITLE
Add `isCircleNode0OrLocal` to `EnvironmentVariables`

### DIFF
--- a/changelog/@unreleased/pr-117.v2.yml
+++ b/changelog/@unreleased/pr-117.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Add `isCircleNode0OrLocal` to `EnvironmentVariables`
+  links:
+  - https://github.com/palantir/gradle-utils/pull/117

--- a/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
+++ b/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
@@ -30,6 +30,12 @@ public abstract class EnvironmentVariables {
         return envVarOrFromTestingProperty("CI").map(_value -> true).orElse(false);
     }
 
+    public final Provider<Boolean> isCircleNode0OrLocal() {
+        return envVarOrFromTestingProperty("CIRCLE_NODE_INDEX")
+                .map(index -> index.equals("0"))
+                .orElse(true);
+    }
+
     public final Provider<String> envVarOrFromTestingProperty(String envVar) {
         Provider<Boolean> testingProvider = getProviderFactory()
                 .gradleProperty("__TESTING")

--- a/environment-variables/src/test/groovy/com/palantir/gradle/utils/environmentvariables/EnvironmentVariablesTest.groovy
+++ b/environment-variables/src/test/groovy/com/palantir/gradle/utils/environmentvariables/EnvironmentVariablesTest.groovy
@@ -17,7 +17,6 @@
 package com.palantir.gradle.utils.environmentvariables
 
 import nebula.test.IntegrationSpec
-import nebula.test.functional.ExecutionResult
 
 class EnvironmentVariablesTest extends IntegrationSpec {
     def setup() {
@@ -31,23 +30,53 @@ class EnvironmentVariablesTest extends IntegrationSpec {
             }
 
             def variables = objects.newInstance(TestClass).environmentVariables
-            println('Variable: ' + variables.envVarOrFromTestingProperty('VARIABLE').get())
+            println('Variable: ' + variables.envVarOrFromTestingProperty('VARIABLE').getOrNull())
+            println('isCircleNode0OrLocal: ' + variables.isCircleNode0OrLocal().getOrNull())
         '''.stripIndent(true)
     }
+
     def 'can get testing variables'() {
         when:
-        ExecutionResult result = runTasksSuccessfully('tasks', '-P__TESTING=true', '-P__TESTING_VARIABLE=test')
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true', '-P__TESTING_VARIABLE=test').standardOutput
 
         then:
-        result.standardOutput.contains("Variable: test")
+        stdout.contains("Variable: test")
     }
 
     def 'can get environment variables'() {
         when:
-        ExecutionResult result = runTasksSuccessfully('tasks')
+        def stdout = runTasksSuccessfully('help').standardOutput
 
         then:
-        result.standardOutput.contains("Variable: actual value")
+        stdout.contains("Variable: actual value")
+    }
+
+    def 'isCircleNode0OrLocal returns true on circle node 0'() {
+        when:
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true', '-P__TESTING_CIRCLE_NODE_INDEX=0').standardOutput
+
+        then:
+        stdout.contains("isCircleNode0OrLocal: true")
+    }
+
+    def 'isCircleNode0OrLocal returns false on circle node 1'() {
+        when:
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true', '-P__TESTING_CIRCLE_NODE_INDEX=1').standardOutput
+
+        then:
+        stdout.contains("isCircleNode0OrLocal: false")
+    }
+
+    def 'isCircleNode0OrLocal returns true locally'() {
+        when:
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true').standardOutput
+
+        then:
+        stdout.contains("isCircleNode0OrLocal: true")
     }
 
 }


### PR DESCRIPTION
## Before this PR
We've copy pasted a bit of code [like this](https://github.com/palantir/gradle-conjure/pull/1349/commits/aee2fb4d124f91c703ff27cb33dc359e8e4c0684#diff-0670ea7749d577d25fbf8fb4c8f30832cc02a74cc508f5ef54c23ffac8b50d62R708-R711) in many places. Copy pasted code is bad.

## After this PR
==COMMIT_MSG==
Add `isCircleNode0OrLocal` to `EnvironmentVariables`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

