### PR TITLE
Ensure that `DevelocityAdapter` is exposed as api instead of implementation

### DIFF
--- a/changelog/@unreleased/pr-188.v2.yml
+++ b/changelog/@unreleased/pr-188.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: Expose `develocity-agent-adapters` as `api` instead of `implementation`.
+  links:
+  - https://github.com/palantir/gradle-utils/pull/188

--- a/develocity-adapter-utils/build.gradle
+++ b/develocity-adapter-utils/build.gradle
@@ -4,5 +4,5 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
     implementation gradleApi()
-    implementation 'com.gradle:develocity-gradle-plugin-adapters'
+    api 'com.gradle:develocity-gradle-plugin-adapters'
 }


### PR DESCRIPTION
## Before this PR
In #187, I reflexively exposed the adapters dependency as `implementation` instead of `api` => consumers have to explicitly import the `develocity-agent-adapters` dependency, which is silly.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Expose `develocity-agent-adapters` as `api` instead of `implementation`.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

