### PR TITLE
`isCi` checks the CI env var value

### DIFF
--- a/changelog/@unreleased/pr-360.v2.yml
+++ b/changelog/@unreleased/pr-360.v2.yml
@@ -1,0 +1,5 @@
+type: fix
+fix:
+  description: '`isCi` checks the CI env var value'
+  links:
+  - https://github.com/palantir/gradle-utils/pull/360

--- a/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
+++ b/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
@@ -27,7 +27,7 @@ public abstract class EnvironmentVariables {
     protected abstract ProviderFactory getProviderFactory();
 
     public final Provider<Boolean> isCi() {
-        return envVarOrFromTestingProperty("CI").map(_value -> true).orElse(false);
+        return envVarOrFromTestingProperty("CI").map(Boolean::parseBoolean).orElse(false);
     }
 
     public final Provider<Boolean> isCircleNode0OrLocal() {

--- a/environment-variables/src/test/groovy/com/palantir/gradle/utils/environmentvariables/EnvironmentVariablesTest.groovy
+++ b/environment-variables/src/test/groovy/com/palantir/gradle/utils/environmentvariables/EnvironmentVariablesTest.groovy
@@ -32,6 +32,7 @@ class EnvironmentVariablesTest extends IntegrationSpec {
             def variables = objects.newInstance(TestClass).environmentVariables
             println('Variable: ' + variables.envVarOrFromTestingProperty('VARIABLE').getOrNull())
             println('isCircleNode0OrLocal: ' + variables.isCircleNode0OrLocal().getOrNull())
+            println('isCi: ' + variables.isCi().getOrNull())
         '''.stripIndent(true)
     }
 
@@ -77,6 +78,33 @@ class EnvironmentVariablesTest extends IntegrationSpec {
 
         then:
         stdout.contains("isCircleNode0OrLocal: true")
+    }
+
+    def 'isCi returns true on circle node'() {
+        when:
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true', '-P__TESTING_CI=true').standardOutput
+
+        then:
+        stdout.contains("isCi: true")
+    }
+
+    def 'isCi returns false locally'() {
+        when:
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true').standardOutput
+
+        then:
+        stdout.contains("isCi: false")
+    }
+
+    def 'isCi returns false if CI=false'() {
+        when:
+        def stdout = runTasksSuccessfully('help',
+                '-P__TESTING=true', '-P__TESTING_CI=false').standardOutput
+
+        then:
+        stdout.contains("isCi: false")
     }
 
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
During testing (in Circle), we might want to simulate local runs. With this change we can now set "__TESTING_CI=false" and simulate the local development - see usage [here](https://github.com/palantir/gradle-failure-reports/compare/cr/test?expand=1#diff-9a847dd1a865a7d034ecf9523b477ad4083d96567fb0837cfaaab156b3e105c8R35)

==COMMIT_MSG==
`isCi` checks the CI env var value
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

