### PR TITLE
fix provider issues in https://github.com/palantir/gradle-utils/pull/383

### DIFF
--- a/changelog/@unreleased/pr-387.v2.yml
+++ b/changelog/@unreleased/pr-387.v2.yml
@@ -1,0 +1,6 @@
+type: fix
+fix:
+  description: fix provider issues in https://github.com/palantir/gradle-utils/pull/383
+    so that exec command is not called every time
+  links:
+  - https://github.com/palantir/gradle-utils/pull/387

--- a/platform/src/main/java/com/palantir/platform/GradleOperatingSystem.java
+++ b/platform/src/main/java/com/palantir/platform/GradleOperatingSystem.java
@@ -28,26 +28,28 @@ public abstract class GradleOperatingSystem {
     @SuppressWarnings("JavaxInjectOnAbstractMethod")
     protected abstract ProviderFactory getProviderFactory();
 
+    private final Provider<OperatingSystem> linuxOperatingSystem = linuxLibcFromLdd();
+
     public final Provider<OperatingSystem> getOperatingSystem() {
         Provider<String> osNameProvider = getProviderFactory().systemProperty("os.name");
 
-        return osNameProvider.flatMap(osName -> {
+        Provider<OperatingSystem> nonLinuxOsProvider = osNameProvider.map(osName -> {
             String lowerCaseOsName = osName.toLowerCase(Locale.ROOT);
 
             if (lowerCaseOsName.startsWith("mac")) {
-                return getProviderFactory().provider(() -> OperatingSystem.MACOS);
+                return OperatingSystem.MACOS;
             }
 
             if (lowerCaseOsName.startsWith("windows")) {
-                return getProviderFactory().provider(() -> OperatingSystem.WINDOWS);
+                return OperatingSystem.WINDOWS;
             }
 
-            if (lowerCaseOsName.startsWith("linux")) {
-                return linuxLibcFromLdd();
-            }
-
-            throw new UnsupportedOperationException("Cannot get platform for operating system " + osName);
+            return null;
         });
+
+        return nonLinuxOsProvider.orElse(linuxOperatingSystem).orElse(osNameProvider.map(osName -> {
+            throw new UnsupportedOperationException("Cannot get platform for operating system " + osName);
+        }));
     }
 
     private Provider<OperatingSystem> linuxLibcFromLdd() {


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
https://github.com/palantir/gradle-utils/pull/383 left the provider usage in a bad state see https://github.com/palantir/gradle-utils/pull/383#discussion_r2171890301
## After this PR
this PR fixes the use of providers in `GradleOperatingSystem` such that we do not run the exec command every time
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
fix provider issues in https://github.com/palantir/gradle-utils/pull/383 so that exec command is not called every time
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

