### PR TITLE
Mark `GradleOperatingSystem::getOperatingSystem()` as `@Internal` so Gradle stops complaining about an unmarked property when `GradleOperatingSystem` is `@Nested` in a task

### DIFF
--- a/changelog/@unreleased/pr-397.v2.yml
+++ b/changelog/@unreleased/pr-397.v2.yml
@@ -1,7 +1,7 @@
 type: fix
 fix:
-  description: Mark GradleOperatingSystem::getOperatingSystem() as `@Internal` so
-    Gradle stops complaining about an unmarked property when we nest GradleOperatingSystem
-    into a task
+  description: Mark `GradleOperatingSystem::getOperatingSystem()` as `@Internal` so
+    Gradle stops complaining about an unmarked property when `GradleOperatingSystem`
+    is `@Nested` in a task
   links:
   - https://github.com/palantir/gradle-utils/pull/397

--- a/changelog/@unreleased/pr-397.v2.yml
+++ b/changelog/@unreleased/pr-397.v2.yml
@@ -1,0 +1,7 @@
+type: fix
+fix:
+  description: Mark GradleOperatingSystem::getOperatingSystem() as `@Internal` so
+    Gradle stops complaining about an unmarked property when we nest GradleOperatingSystem
+    into a task
+  links:
+  - https://github.com/palantir/gradle-utils/pull/397

--- a/platform/src/main/java/com/palantir/platform/GradleOperatingSystem.java
+++ b/platform/src/main/java/com/palantir/platform/GradleOperatingSystem.java
@@ -33,7 +33,7 @@ public abstract class GradleOperatingSystem {
 
     /**
      * Because this is prefixed with get-, Gradle thinks this is a property.
-     * If GradleOperatingSystem is injected with @Nested into a Gradle task, Gradle will nag you to mark
+     * If GradleOperatingSystem is @Nested into a Gradle task, Gradle will nag you to mark
      * the property GradleOperatingSystem.operatingSystem as @Input, @Output, or @Internal
      * Hence, we mark it as @Internal
      */

--- a/platform/src/main/java/com/palantir/platform/GradleOperatingSystem.java
+++ b/platform/src/main/java/com/palantir/platform/GradleOperatingSystem.java
@@ -20,6 +20,7 @@ import java.util.Locale;
 import javax.inject.Inject;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Internal;
 import org.gradle.process.ExecOutput;
 import org.gradle.process.ExecResult;
 
@@ -30,6 +31,13 @@ public abstract class GradleOperatingSystem {
 
     private final Provider<OperatingSystem> linuxOperatingSystem = linuxLibcFromLdd();
 
+    /**
+     * Because this is prefixed with get-, Gradle thinks this is a property.
+     * If GradleOperatingSystem is injected with @Nested into a Gradle task, Gradle will nag you to mark
+     * the property GradleOperatingSystem.operatingSystem as @Input, @Output, or @Internal
+     * Hence, we mark it as @Internal
+     */
+    @Internal
     public final Provider<OperatingSystem> getOperatingSystem() {
         Provider<String> osNameProvider = getProviderFactory().systemProperty("os.name");
 


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

If you nest GradleOperatingSystem into a task, Gradle will take GradleOperatingSystem.operatingSystem as a property due to the method being named getOperatingSystem. (This is possibly erroneous behavior on Gradle's part). 

Gradle will nag you to mark the property  as `@Input`, `@Output`, or `@Internal`.

This forces us to inject ObjectFactory and instantiate GradleOperatingSystem with newInstance. 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Gradle stops complaining about an unmarked property when we nest GradleOperatingSystem into a task.

We can now have GradleOperatingSystem be `@Nested` into a task

==COMMIT_MSG==
Mark `GradleOperatingSystem::getOperatingSystem()` as `@Internal` so Gradle stops complaining about an unmarked property when `GradleOperatingSystem` is `@Nested` in a task
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

