### PR TITLE
use api dependency between `providers` and `exec`

### DIFF
--- a/exec/build.gradle
+++ b/exec/build.gradle
@@ -19,7 +19,7 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
     implementation gradleApi()
-    implementation project(':providers')
+    api project(':providers')
 
     annotationProcessor 'org.immutables:value'
 


### PR DESCRIPTION
## Before this PR
Was using implementation which caused `validatePlugins` to fail 

## After this PR
Now use `api` which resolves this issue
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
use api dependency between `providers` and `exec`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

