### PR TITLE
add `CIRCLE_HOME_DIRECTORY` to `CircleCiArtifacts`

### DIFF
--- a/circleci-artifacts/src/main/java/com/palantir/gradle/utils/circleciartifacts/CircleCiArtifacts.java
+++ b/circleci-artifacts/src/main/java/com/palantir/gradle/utils/circleciartifacts/CircleCiArtifacts.java
@@ -55,7 +55,7 @@ public abstract class CircleCiArtifacts {
                 .orElse("/home/circleci/");
         Provider<String> circleArtifacts = physicalArtifactPath
                 .map(file -> file.getAsFile().getAbsolutePath())
-                .zip(circleHome, (artifacts, home) -> artifacts.replace(home, "/~/"));
+                .zip(circleHome, (artifacts, home) -> artifacts.replaceFirst(home, "/~/"));
         Provider<String> circleUrl = getVariables()
                 .envVarOrFromTestingProperty("CIRCLE_BUILD_URL")
                 .map(CircleCiArtifacts::extractDomain)

--- a/circleci-artifacts/src/main/java/com/palantir/gradle/utils/circleciartifacts/CircleCiArtifacts.java
+++ b/circleci-artifacts/src/main/java/com/palantir/gradle/utils/circleciartifacts/CircleCiArtifacts.java
@@ -50,9 +50,12 @@ public abstract class CircleCiArtifacts {
         Provider<String> circleProjectReponame = getVariables().envVarOrFromTestingProperty("CIRCLE_PROJECT_REPONAME");
         Provider<String> circleBuildNum = getVariables().envVarOrFromTestingProperty("CIRCLE_BUILD_NUM");
         Provider<String> circleNodeIndex = getVariables().envVarOrFromTestingProperty("CIRCLE_NODE_INDEX");
+        Provider<String> circleHome = getVariables()
+                .envVarOrFromTestingProperty("CIRCLE_HOME_DIRECTORY")
+                .orElse("/home/circleci/");
         Provider<String> circleArtifacts = physicalArtifactPath
                 .map(file -> file.getAsFile().getAbsolutePath())
-                .map(artifacts -> artifacts.replace("/home/circleci/", "/~/"));
+                .zip(circleHome, (artifacts, home) -> artifacts.replace(home, "/~/"));
         Provider<String> circleUrl = getVariables()
                 .envVarOrFromTestingProperty("CIRCLE_BUILD_URL")
                 .map(CircleCiArtifacts::extractDomain)

--- a/circleci-artifacts/src/test/groovy/com/palantir/gradle/utils/circleciartifacts/CircleCiArtifactsTest.groovy
+++ b/circleci-artifacts/src/test/groovy/com/palantir/gradle/utils/circleciartifacts/CircleCiArtifactsTest.groovy
@@ -104,4 +104,30 @@ class CircleCiArtifactsTest extends IntegrationSpec {
         result.standardOutput.find "External location: palantir/gradle-utils/1234/artifacts/2345/.*/location/in/artifacts"
         result.standardOutput.find "Circle link: https://<circle_url>/output/job/abc-123-def-456/artifacts/2345/.*/location/in/artifacts"
     }
+
+
+    def 'handles custom CIRCLE_HOME_DIRECTORY environment variable'() {
+        given:
+        def customHome = '/custom/home/path/'
+        file('gradle.properties') << """
+            __TESTING = true
+            __TESTING_CI=true
+            __TESTING_CIRCLE_ARTIFACTS=${customHome}circle-artifacts
+            __TESTING_CIRCLE_PROJECT_USERNAME=palantir
+            __TESTING_CIRCLE_PROJECT_REPONAME=gradle-utils
+            __TESTING_CIRCLE_BUILD_NUM=1234
+            __TESTING_CIRCLE_NODE_INDEX=2345
+            __TESTING_CIRCLE_BUILD_URL=https://circleci.com/gh/palantir/gradle-utils/1234
+            __TESTING_CIRCLE_WORKFLOW_JOB_ID=abc-123-def-456
+            __TESTING_CIRCLE_HOME_DIRECTORY=${customHome}
+        """.stripIndent(true)
+
+        when: 'running the task to print the path and location'
+        def result = runTasksSuccessfully('printCircleCiLocation')
+
+        then: 'the custom home directory is properly replaced with /~/'
+        result.standardOutput.find "Physical path: ${customHome}circle-artifacts/location/in/artifacts"
+        result.standardOutput.find 'External location: palantir/gradle-utils/1234/artifacts/2345/~/circle-artifacts/location/in/artifacts'
+        result.standardOutput.find 'Circle link: https://circleci.com/output/job/abc-123-def-456/artifacts/2345/~/circle-artifacts/location/in/artifacts'
+    }
 }


### PR DESCRIPTION
## Before this PR
If we want to use `CircleCiArtifacts` in `BetterExec` we need to have full parity which includes checking for the `CIRCLE_HOME_DIRECTORY` env var

## After this PR
Now we check for the `CIRCLE_HOME_DIRECTORY` before defaulting to `/home/circleci/`
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
add `CIRCLE_HOME_DIRECTORY` to `CircleCiArtifacts`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

