### PR TITLE
Add `isInTestMode` method

### DIFF
--- a/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
+++ b/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
@@ -44,8 +44,10 @@ public abstract class EnvironmentVariables {
     }
 
     public final Provider<String> envVarOrFromTestingProperty(String envVar) {
-        return isInTestMode().flatMap(isTesting ->
-                isTesting ? testingProperty(envVar) : getProviderFactory().environmentVariable(envVar));
+        return isInTestMode()
+                .flatMap(isTesting -> isTesting
+                        ? testingProperty(envVar)
+                        : getProviderFactory().environmentVariable(envVar));
     }
 
     private Provider<String> testingProperty(String name) {

--- a/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
+++ b/environment-variables/src/main/java/com/palantir/gradle/utils/environmentvariables/EnvironmentVariables.java
@@ -36,13 +36,15 @@ public abstract class EnvironmentVariables {
                 .orElse(true);
     }
 
-    public final Provider<String> envVarOrFromTestingProperty(String envVar) {
-        Provider<Boolean> testingProvider = getProviderFactory()
+    public final Provider<Boolean> isInTestMode() {
+        return getProviderFactory()
                 .gradleProperty("__TESTING")
                 .map(Boolean::parseBoolean)
                 .orElse(false);
+    }
 
-        return testingProvider.flatMap(isTesting ->
+    public final Provider<String> envVarOrFromTestingProperty(String envVar) {
+        return isInTestMode().flatMap(isTesting ->
                 isTesting ? testingProperty(envVar) : getProviderFactory().environmentVariable(envVar));
     }
 


### PR DESCRIPTION

## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
Relevant PR: https://github.com/palantir/gradle-plugin-testing/pull/344. 

The `@GradlePluginTests` framework adds by default `-P__TESTING=true` [here](https://github.com/palantir/gradle-plugin-testing/pull/344/changes#diff-8afe3ab707105dc3a3bc9219fdf31f7eb738ec7513b3a0d039f01ca51fd4a73eR42), This can be used by the tested plugins eg. (gradle-jdks) to implement specialized setup when in test mode.

==COMMIT_MSG==
Add `isInTestMode` method
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

