### PR TITLE
Set javaTarget=11 for subprojects requiring Java 11 compatibility

### DIFF
--- a/exec/build.gradle
+++ b/exec/build.gradle
@@ -37,6 +37,6 @@ moduleJvmArgs {
 }
 
 // Needs to be kept at Java 11 to keep compatibility with `GradleOperationSystem` due to https://github.com/palantir/gradle-jdks/commit/6f0392f7ad8bbf6e2106531ce3e7b72814e292d9#diff-74e7049ae20f3b2702c8fdf3ac93ecddd1af9eac4b5876fcec1d082ae3a800b5R47-R48
-java {
-    sourceCompatibility = 11
+javaVersion {
+    target = 11
 }

--- a/gradle/jdks/11/linux-glibc/aarch64/download-url
+++ b/gradle/jdks/11/linux-glibc/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-linux-aarch64.tar.gz

--- a/gradle/jdks/11/linux-glibc/aarch64/local-path
+++ b/gradle/jdks/11/linux-glibc/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1-glibc

--- a/gradle/jdks/11/linux-glibc/x86-64/download-url
+++ b/gradle/jdks/11/linux-glibc/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-linux-x64.tar.gz

--- a/gradle/jdks/11/linux-glibc/x86-64/local-path
+++ b/gradle/jdks/11/linux-glibc/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1-glibc

--- a/gradle/jdks/11/linux-glibc/x86/download-url
+++ b/gradle/jdks/11/linux-glibc/x86/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-linux-i386.tar.gz

--- a/gradle/jdks/11/linux-glibc/x86/local-path
+++ b/gradle/jdks/11/linux-glibc/x86/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1-glibc

--- a/gradle/jdks/11/linux-musl/aarch64/download-url
+++ b/gradle/jdks/11/linux-musl/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-alpine-linux-aarch64.tar.gz

--- a/gradle/jdks/11/linux-musl/aarch64/local-path
+++ b/gradle/jdks/11/linux-musl/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1-musl

--- a/gradle/jdks/11/linux-musl/x86-64/download-url
+++ b/gradle/jdks/11/linux-musl/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-alpine-linux-x64.tar.gz

--- a/gradle/jdks/11/linux-musl/x86-64/local-path
+++ b/gradle/jdks/11/linux-musl/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1-musl

--- a/gradle/jdks/11/macos/aarch64/download-url
+++ b/gradle/jdks/11/macos/aarch64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-macosx-aarch64.tar.gz

--- a/gradle/jdks/11/macos/aarch64/local-path
+++ b/gradle/jdks/11/macos/aarch64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1

--- a/gradle/jdks/11/macos/x86-64/download-url
+++ b/gradle/jdks/11/macos/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-macosx-x64.tar.gz

--- a/gradle/jdks/11/macos/x86-64/local-path
+++ b/gradle/jdks/11/macos/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1

--- a/gradle/jdks/11/windows/x86-64/download-url
+++ b/gradle/jdks/11/windows/x86-64/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-windows-x64-jdk.zip

--- a/gradle/jdks/11/windows/x86-64/local-path
+++ b/gradle/jdks/11/windows/x86-64/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1

--- a/gradle/jdks/11/windows/x86/download-url
+++ b/gradle/jdks/11/windows/x86/download-url
@@ -1,0 +1,1 @@
+https://corretto.aws/downloads/resources/11.0.30.7.1/amazon-corretto-11.0.30.7.1-windows-i386-jdk.zip

--- a/gradle/jdks/11/windows/x86/local-path
+++ b/gradle/jdks/11/windows/x86/local-path
@@ -1,0 +1,1 @@
+amazon-corretto-11.0.30.7.1

--- a/platform/build.gradle
+++ b/platform/build.gradle
@@ -17,7 +17,8 @@ dependencies {
 moduleJvmArgs {
     opens 'java.base/java.lang'
 }
+
 // Needs to be kept at Java 11 to keep compatibility with https://github.com/palantir/gradle-jdks/commit/6f0392f7ad8bbf6e2106531ce3e7b72814e292d9#diff-74e7049ae20f3b2702c8fdf3ac93ecddd1af9eac4b5876fcec1d082ae3a800b5R47-R48
-java {
-    sourceCompatibility = 11
+javaVersion {
+    target = 11
 }

--- a/platform/src/main/java/com/palantir/platform/OperatingSystem.java
+++ b/platform/src/main/java/com/palantir/platform/OperatingSystem.java
@@ -49,11 +49,17 @@ public enum OperatingSystem {
     }
 
     public Optional<String> glibcOrMuslDistribution() {
-        return switch (this) {
-            case LINUX_MUSL -> Optional.of("musl");
-            case LINUX_GLIBC -> Optional.of("glibc");
-            case MACOS, WINDOWS -> Optional.empty();
-        };
+        switch (this) {
+            case LINUX_MUSL:
+                return Optional.of("musl");
+            case LINUX_GLIBC:
+                return Optional.of("glibc");
+            case MACOS:
+            case WINDOWS:
+                return Optional.empty();
+            default:
+                throw new IllegalArgumentException("invalid OperatingSystem");
+        }
     }
 
     public static Optional<OperatingSystem> fromString(String osUiName) {

--- a/providers/build.gradle
+++ b/providers/build.gradle
@@ -29,6 +29,6 @@ moduleJvmArgs {
 }
 
 // Needs to be kept at Java 11 to keep compatibility with `GradleOperationSystem` due to https://github.com/palantir/gradle-jdks/commit/6f0392f7ad8bbf6e2106531ce3e7b72814e292d9#diff-74e7049ae20f3b2702c8fdf3ac93ecddd1af9eac4b5876fcec1d082ae3a800b5R47-R48
-java {
-    sourceCompatibility = 11
+javaVersion {
+    target = 11
 }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
The [javaCompiler changes](https://github.com/palantir/gradle-baseline/blob/f7c79ed0478d3ac02011988b6daece784372bf22/gradle-baseline-java/src/main/java/com/palantir/baseline/plugins/javaversions/BaselineJavaVersion.java#L202-L208) will cause [sourceCompatibility setup to be discarded](https://github.com/palantir/gradle-utils/blob/develop/platform/build.gradle#L22)

## After this PR
Internal link: https://pl.ntr/2zH. We need to keep sourceCompatibility set to 11 (because some clients eg. gradle-jdks are still on Java 11).

<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Set javaTarget=11 for subprojects requiring Java 11 compatibility
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

